### PR TITLE
Converted the citybike icon layer to a almost transparent circle laye…

### DIFF
--- a/hsl-gl-map-v9-citybikes.json
+++ b/hsl-gl-map-v9-citybikes.json
@@ -91,78 +91,49 @@
     },
     {
       "id": "poi_label_citybike-station",
-      "type": "symbol",
       "metadata": {
         "mapbox:group": "1457010266398.4177"
       },
+      "type": "circle",
       "source": "citybike",
       "source-layer": "stations",
       "minzoom": 14,
       "interactive": true,
-      "filter": [
-        "==",
-        "$type",
-        "Point"
-      ],
       "layout": {
-        "text-optional": true,
-        "text-size": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "circle-color": "rgba(255,255,255,0.1)",
+        "circle-radius": {
+          "base": 1.08,
           "stops": [
             [
-              0,
-              8
+              1,
+              0
             ],
             [
-              15,
-              10
+              120,
+              1
+            ],
+            [
+              22,
+              24
             ]
           ]
         },
-        "text-allow-overlap": false,
-        "icon-offset": [
-          0,
-          -6
-        ],
-        "icon-image": "icon-citybike-station",
-        "text-ignore-placement": false,
-        "text-font": [
-          "Gotham Rounded Medium"
-        ],
-        "icon-allow-overlap": false,
-        "symbol-placement": "point",
-        "visibility": "visible",
-        "text-offset": [
-          0,
-          0.5
-        ],
-        "icon-optional": false,
-        "icon-size": {
+        "circle-opacity": {
           "base": 1,
           "stops": [
             [
-              13,
-              0.8
+              11,
+              0.6
             ],
             [
-              20,
-              1.2
+              14,
+              1
             ]
           ]
-        },
-        "text-anchor": "top",
-        "text-max-width": 8,
-        "icon-ignore-placement": false
-      },
-      "paint": {
-        "text-color": "#666",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,1.0)",
-        "text-halo-blur": 0,
-        "icon-translate": [
-          0,
-          0
-        ],
-        "icon-opacity": 1
+        }
       }
     }
   ]


### PR DESCRIPTION
Converted the citybike icon layer to a almost transparent circle layer so that the mobile app can just use custom icons on top of the circles and still let mapbox handle the clicking logic