### PR TITLE
add some bridges to map

### DIFF
--- a/hsl-gl-map-v9-base.json
+++ b/hsl-gl-map-v9-base.json
@@ -2839,6 +2839,98 @@
             }
         },
         {
+            "id": "bridge_pedestrian",
+            "type": "line",
+            "source": "vector",
+            "source-layer": "road",
+            "paint": {
+                "line-width": {
+                    "base": 1.55,
+                    "stops": [
+                        [
+                            4,
+                            0.25
+                        ],
+                        [
+                            20,
+                            16.5
+                        ]
+                    ]
+                },
+                "line-color": "rgba(255, 255, 255, 1)"
+            },
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "pedestrian"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ]
+        },
+        {
+            "id": "bridge_pedestrian_case",
+            "type": "line",
+            "source": "vector",
+            "source-layer": "road",
+            "layout": {
+                "visibility": "visible",
+                "line-join": "round",
+                "line-cap": "butt",
+                "line-miter-limit": 2
+            },
+            "paint": {
+                "line-color": "#ccc",
+                "line-width": {
+                    "base": 1.6,
+                    "stops": [
+                        [
+                            12,
+                            0.25
+                        ],
+                        [
+                            20,
+                            6
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.55,
+                    "stops": [
+                        [
+                            4,
+                            0.25
+                        ],
+                        [
+                            20,
+                            30
+                        ]
+                    ]
+                }
+            },
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "pedestrian"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ]
+        },
+        {
             "id": "bridge_street_case",
             "type": "line",
             "source": "vector",

--- a/hsl-gl-map-v9-base.json
+++ b/hsl-gl-map-v9-base.json
@@ -2839,44 +2839,6 @@
             }
         },
         {
-            "id": "bridge_pedestrian",
-            "type": "line",
-            "source": "vector",
-            "source-layer": "road",
-            "paint": {
-                "line-width": {
-                    "base": 1.55,
-                    "stops": [
-                        [
-                            4,
-                            0.25
-                        ],
-                        [
-                            20,
-                            16.5
-                        ]
-                    ]
-                },
-                "line-color": "rgba(255, 255, 255, 1)"
-            },
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "pedestrian"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ]
-        },
-        {
             "id": "bridge_pedestrian_case",
             "type": "line",
             "source": "vector",
@@ -2915,6 +2877,44 @@
                         ]
                     ]
                 }
+            },
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "pedestrian"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ]
+        },
+        {
+            "id": "bridge_pedestrian",
+            "type": "line",
+            "source": "vector",
+            "source-layer": "road",
+            "paint": {
+                "line-width": {
+                    "base": 1.55,
+                    "stops": [
+                        [
+                            4,
+                            0.25
+                        ],
+                        [
+                            20,
+                            16.5
+                        ]
+                    ]
+                },
+                "line-color": "rgba(255, 255, 255, 1)"
+            },
+            "layout": {
+                "visibility": "visible"
             },
             "filter": [
                 "all",

--- a/hsl-gl-map-v9-base.json
+++ b/hsl-gl-map-v9-base.json
@@ -1234,6 +1234,59 @@
             }
         },
         {
+            "id": "tunnel_road_path_cycleway",
+            "type": "line",
+            "source": "vector",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "structure",
+                        "tunnel"
+                    ],
+                    [
+                        "in",
+                        "type",
+                        "cycleway",
+                        "pedestrian",
+                        "track"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#fff",
+                "line-width": {
+                    "base": 1.55,
+                    "stops": [
+                        [
+                            0,
+                            1.5
+                        ],
+                        [
+                            22,
+                            26
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    1,
+                    0
+                ]
+            }
+        },
+        {
             "id": "road_subway",
             "type": "line",
             "source": "vector",
@@ -1849,9 +1902,10 @@
                 [
                     "all",
                     [
-                        "!=",
+                        "!in",
                         "structure",
-                        "bridge"
+                        "bridge",
+                        "tunnel"
                     ],
                     [
                         "in",

--- a/hsl-gl-map-v9-base.json
+++ b/hsl-gl-map-v9-base.json
@@ -1347,54 +1347,6 @@
             }
         },
         {
-            "id": "bridge_subway",
-            "type": "line",
-            "source": "vector",
-            "source-layer": "road",
-            "filter": [
-                "all",
-                [
-                    "!=",
-                    "osm_id",
-                    120809795
-                ],
-                [
-                    "==",
-                    "class",
-                    "major_rail"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "==",
-                    "type",
-                    "subway"
-                ]
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": "#bbb",
-                "line-width": {
-                    "base": 1.4,
-                    "stops": [
-                        [
-                            6,
-                            0.5
-                        ],
-                        [
-                            20,
-                            20
-                        ]
-                    ]
-                }
-            }
-        },
-        {
             "id": "waterway",
             "ref": "waterway_case",
             "paint": {
@@ -2680,6 +2632,54 @@
                         [
                             22,
                             8
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge_subway",
+            "type": "line",
+            "source": "vector",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                [
+                    "!=",
+                    "osm_id",
+                    120809795
+                ],
+                [
+                    "==",
+                    "class",
+                    "major_rail"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "==",
+                    "type",
+                    "subway"
+                ]
+            ],
+            "layout": {
+                "visibility": "visible"
+            },
+            "paint": {
+                "line-color": "#bbb",
+                "line-width": {
+                    "base": 1.4,
+                    "stops": [
+                        [
+                            6,
+                            0.5
+                        ],
+                        [
+                            20,
+                            20
                         ]
                     ]
                 }


### PR DESCRIPTION
Some of the bridges were missing:
![pedestrian bridges](https://user-images.githubusercontent.com/5735068/45495089-356d0e00-b77b-11e8-975f-91407f9dcc79.png)

created a similar style as in bridge_path:
![bridges](https://user-images.githubusercontent.com/5735068/45495436-ec698980-b77b-11e8-9d6e-020f3c09a222.png)
