### PR TITLE
refactor(fonts): Updated glyph source URL for mapfonts

### DIFF
--- a/_oldstyle/hsl-gl-map-v9-style.json
+++ b/_oldstyle/hsl-gl-map-v9-style.json
@@ -22,7 +22,7 @@
         }
     },
     "sprite": "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/sprite",
-    "glyphs": "https://static.hsl.fi/mapfonts/{fontstack}/{range}.pbf",
+    "glyphs": "https://static.hsldev.com/mapfonts/{fontstack}/{range}.pbf",
     "layers": [],
     "created": "2016-05-12T07:20:14.210Z",
     "id": "cio3ytjzp005dbzm1uaowh9s3",

--- a/simple-style.json
+++ b/simple-style.json
@@ -56,7 +56,7 @@
     }
   },
   "sprite": "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/sprite",
-  "glyphs": "https://static.hsl.fi/mapfonts/{fontstack}/{range}.pbf",
+  "glyphs": "https://static.hsldev.com/mapfonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/style.json
+++ b/style.json
@@ -88,7 +88,7 @@
     }
   },
   "sprite": "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/sprite",
-  "glyphs": "https://static.hsl.fi/mapfonts/{fontstack}/{range}.pbf",
+  "glyphs": "https://static.hsldev.com/mapfonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",
@@ -168,9 +168,9 @@
       "source": "vector",
       "source-layer": "landuse",
       "filter": [
-      "==",
-      "type",
-      "playground"
+        "==",
+        "type",
+        "playground"
       ],
       "layout": {
         "visibility": "visible"

--- a/style/hsl-gl-map-v9-style.json
+++ b/style/hsl-gl-map-v9-style.json
@@ -47,7 +47,7 @@
   "pitch": 0,
   "sources": {},
   "sprite": "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/sprite",
-  "glyphs": "https://static.hsl.fi/mapfonts/{fontstack}/{range}.pbf",
+  "glyphs": "https://static.hsldev.com/mapfonts/{fontstack}/{range}.pbf",
   "layers": [],
   "created": "2016-05-12T07:20:14.210Z",
   "id": "cio3ytjzp005dbzm1uaowh9s3",


### PR DESCRIPTION
The fontstack content is same as before. Only location changed from static.hsl.fi to static.hsldev.com.