### PR TITLE
MM-329: Add parsed route id filtering capability

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,8 +303,18 @@ function extendStyle(style, options) {
             ["==", ["get", "direction"], f.direction],
           ];
         }
+        if (f.idParsed && f.direction) {
+          return [
+            "all",
+            ["==", ["get", "routeIdParsed"], f.idParsed],
+            ["==", ["get", "direction"], f.direction],
+          ];
+        }
         if (f.id) {
           return ["==", ["get", "routeId"], f.id];
+        }
+        if (f.idParsed) {
+          return ["==", ["get", "routeIdParsed"], f.idParsed];
         }
         return undefined;
       })


### PR DESCRIPTION
Regular jore-id filtering does still work.