### PR TITLE
MM-30: Add english map theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ There're no limits which style components can be enabled or disabled at the same
 |-------------------------------|------------------------------------------------------------------|-------------------|:------------------:|
 | `text_sv`                     | Shows texts in Swedish                                           | `text_fisv`       |                    |
 | `text_fisv`                   | Shows texts in both Finnish and Swedish                          | `text_sv`         |                    |
+| `text_en`                     | Shows texts in English where possible                            | `text_sv, text_fisv`|                    |
 | `regular_routes`              | Shows only regular routes (filters near bus routes)              | `near_bus_routes` |                    |
 | `near_bus_routes`             | Shows only near bus routes                                       | `regular_routes`  |                    |
 | `routes_with_departures_only` | Shows only routes that are currently used                        |                   |         x          |
@@ -130,6 +131,7 @@ const style = generateStyle({
     // Themes
     text_sv: { enabled: false },
     text_fisv: { enabled: false },
+    text_en: { enabled: false },
     regular_routes: { enabled: false },
     near_bus_routes: { enabled: false },
     routes_with_departures_only: { enabled: true }, // Enabled by default. Doesn't do anything until routes is enabled.

--- a/cli/render.js
+++ b/cli/render.js
@@ -28,6 +28,7 @@ module.exports = () => {
       // Themes
       text_sv: { enabled: false },
       text_fisv: { enabled: false },
+      text_en: { enabled: false },
       regular_routes: { enabled: false },
       near_bus_routes: { enabled: false },
       routes_with_departures_only: { enabled: true }, // Enabled by default. Doesn't do anything until routes is enabled

--- a/index.js
+++ b/index.js
@@ -106,6 +106,13 @@ const components = [
     dependencies: ["text"],
   },
   {
+    id: "text_en",
+    enabled: false,
+    description: "Englanninkieliset tekstit",
+    style: require("./style/hsl-map-theme-text-en.json"),
+    dependencies: ["text"],
+  },
+  {
     id: "regular_routes",
     enabled: false,
     description: "Linjaviivat ilman lähibusseja",

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ const style = require("./index").generateStyle({
     // Themes
     text_sv: { enabled: false },
     text_fisv: { enabled: false },
+    text_en: { enabled: false },
     regular_routes: { enabled: false },
     near_bus_routes: { enabled: false },
     routes_with_departures_only: { enabled: true }, // Enabled by default. Doesn't do anything until routes is enabled.

--- a/style/hsl-map-theme-text-en.json
+++ b/style/hsl-map-theme-text-en.json
@@ -1,0 +1,100 @@
+{
+  "layers": [
+    {
+      "id": "label_poi_general",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_poi_park",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_poi_harbour",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_water",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_place_island",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_road_path_cycleway_track_service",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_road_street",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_road_primary",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_place_other",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_place_town",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_place_city",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "label_country",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    },
+    {
+      "id": "icon_subway-station",
+      "layout": {
+        "text-field": "{nameFi}"
+      }
+    },
+    {
+      "id": "icon_bus-station",
+      "layout": {
+        "text-field": "{nameFi}"
+      }
+    },
+    {
+      "id": "icon_railway-station",
+      "layout": {
+        "text-field": "{nameFi}"
+      }
+    },
+    {
+      "id": "icon_aerodrome",
+      "layout": {
+        "text-field": "{name_en}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added toggleable english map style, which uses english text where it's available. Fallback to finnish if english text doesn't exist.