### PR TITLE
MM-123: Display unit and entrance lettering for buildings

### DIFF
--- a/style.json
+++ b/style.json
@@ -2517,7 +2517,22 @@
       "source-layer": "housenumber",
       "filter": ["==", "$type", "Point"],
       "layout": {
-        "text-field": "{housenumber}",
+        "text-field": [
+          "case",
+            [
+              "to-boolean",
+              ["get", "entrance"]
+            ],
+            [
+              "concat",
+              ["get", "housenumber"],
+              [
+                "coalesce",
+                ["get", "unit"],
+                ["get", "ref"]
+              ]
+        ],
+        ["get", "housenumber"]],
         "text-size": {
           "stops": [
             [15, 8],

--- a/style.json
+++ b/style.json
@@ -2511,28 +2511,53 @@
       }
     },
     {
+      "id": "label_entrance",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "housenumber",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["!=", "entrance", ""]
+      ],
+      "layout": {
+        "text-field":
+          [
+            "concat",
+            ["get", "housenumber"],
+            [
+              "coalesce",
+              ["get", "unit"],
+              ["get", "ref"]
+            ]
+        ],
+        "text-size": {
+          "stops": [
+            [15, 8],
+            [22, 17]
+          ]
+        },
+        "text-font": ["Gotham Rounded Book"]
+      },
+      "paint": {
+        "text-color": "#999",
+        "text-opacity": 0.7
+      }
+    },
+    {
       "id": "label_housenum",
       "type": "symbol",
       "source": "vector",
       "source-layer": "housenumber",
-      "filter": ["==", "$type", "Point"],
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "entrance", ""]
+      ],
       "layout": {
-        "text-field": [
-          "case",
-            [
-              "to-boolean",
-              ["get", "entrance"]
-            ],
-            [
-              "concat",
-              ["get", "housenumber"],
-              [
-                "coalesce",
-                ["get", "unit"],
-                ["get", "ref"]
-              ]
-        ],
-        ["get", "housenumber"]],
+        "text-field": "{housenumber}",
         "text-size": {
           "stops": [
             [15, 8],

--- a/style/hsl-map-style-text.json
+++ b/style/hsl-map-style-text.json
@@ -1,48 +1,85 @@
 {
   "layers": [
     {
+      "id": "label_entrance",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "housenumber",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "!=",
+          "entrance",
+          ""
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "concat",
+          [
+            "get",
+            "housenumber"
+          ],
+          [
+            "coalesce",
+            [
+              "get",
+              "unit"
+            ],
+            [
+              "get",
+              "ref"
+            ]
+          ]
+        ],
+        "text-size": {
+          "stops": [
+            [
+              15,
+              8
+            ],
+            [
+              22,
+              17
+            ]
+          ]
+        },
+        "text-font": [
+          "Gotham Rounded Book"
+        ]
+      },
+      "paint": {
+        "text-color": "#999",
+        "text-opacity": 0.7
+      }
+    },
+    {
       "id": "label_housenum",
       "type": "symbol",
       "source": "vector",
       "source-layer": "housenumber",
+      "minzoom": 14,
       "filter": [
-        "==",
-        "$type",
-        "Point"
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "entrance",
+          ""
+        ]
       ],
       "layout": {
-        "text-field": [
-          "case",
-          [
-            "to-boolean",
-            [
-              "get",
-              "entrance"
-            ]
-          ],
-          [
-            "concat",
-            [
-              "get",
-              "housenumber"
-            ],
-            [
-              "coalesce",
-              [
-                "get",
-                "unit"
-              ],
-              [
-                "get",
-                "ref"
-              ]
-            ]
-          ],
-          [
-            "get",
-            "housenumber"
-          ]
-        ],
+        "text-field": "{housenumber}",
         "text-size": {
           "stops": [
             [

--- a/style/hsl-map-style-text.json
+++ b/style/hsl-map-style-text.json
@@ -11,7 +11,38 @@
         "Point"
       ],
       "layout": {
-        "text-field": "{housenumber}",
+        "text-field": [
+          "case",
+          [
+            "to-boolean",
+            [
+              "get",
+              "entrance"
+            ]
+          ],
+          [
+            "concat",
+            [
+              "get",
+              "housenumber"
+            ],
+            [
+              "coalesce",
+              [
+                "get",
+                "unit"
+              ],
+              [
+                "get",
+                "ref"
+              ]
+            ]
+          ],
+          [
+            "get",
+            "housenumber"
+          ]
+        ],
         "text-size": {
           "stops": [
             [


### PR DESCRIPTION
Usually the lettering is in the "unit" property. Fallback is "ref" since sometimes that is used too. If the node in question isn't an entrance/does not have the entrance tag, the map will only display the housenumber.