### PR TITLE
Fix the replacable sprite url value

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ const REPLACEABLE_VALUES = {
       "https://hslstoragestatic.azureedge.net/mapfonts/{fontstack}/{range}.pbf",
   },
   spriteUrl: {
-    default:
-      "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/sprite-v1.0.0/sprite",
+    default: "https://hslstoragekarttatuotanto.z6.web.core.windows.net/sprite",
   },
 };
 


### PR DESCRIPTION
The sprite url was still the old one on the configuration that is used to replace the default values. That prevented user to use their custom sprite url.