### PR TITLE
AB#38162: Allow full replacement of the source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ import { generateStyle } from "hsl-map-style";
 
 const style = generateStyle({
   sourcesUrl: "https://cdn.digitransit.fi/", // <-- You can override the default sources URL. The default is https://api.digitransit.fi/
+  // OR sourcesUrl: ["https://cdn.digitransit.fi/", "vector"], // <---- [{ HOST_URL }, { SOURCE_NAME }] Use this to replace the specified source URL as a whole instead of only the hostname
   glyphsUrl: "", // Possibility to overwrite fonts url, an empty string does nothing
   spriteUrl: "", // Possibility to overwrite sprite url
   queryParams: [ // It's possible to add query parameters to urls, for example apikeys.

--- a/index.js
+++ b/index.js
@@ -253,8 +253,17 @@ function replaceInStyle(style, options) {
 
   forEach(values, (value) => {
     if (value.replacement) {
-      const replaceableRegexp = new RegExp(value.default, "g");
-      replacedStyle = replacedStyle.replace(replaceableRegexp, value.replacement);
+      if (Array.isArray(value.replacement)) {
+        /* Full replacement of a selected source URL.
+           This condition expects replacements like this: [fullReplacementUrl, fullReplacementTarget] in order to fully replace the source url instead of using RegExp */
+        const parsedReplacedStyle = JSON.parse(replacedStyle);
+        const [fullReplacementUrl, fullReplacementTarget] = value.replacement;
+        parsedReplacedStyle.sources[fullReplacementTarget].url = fullReplacementUrl;
+        replacedStyle = JSON.stringify(parsedReplacedStyle);
+      } else {
+        const replaceableRegexp = new RegExp(value.default, "g");
+        replacedStyle = replacedStyle.replace(replaceableRegexp, value.replacement);
+      }
     }
   });
 


### PR DESCRIPTION
This allows easier usage `mbtiles://{local_tiles}` type of URLs on tile servers, especially meant for our new tileserver `hsl-map-tileserver-gl`